### PR TITLE
chore: add support for for Laravel 9 and 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php" : "^7.2 || ^8.0",
         "nesbot/carbon": "^2.5",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0",
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "psr/http-client": "^1.0",
         "php-http/discovery": "^1.6",
         "php-http/client-common": "^2.0",


### PR DESCRIPTION
add support for for Laravel 9 and 10

## Description
Only allowed installation of illuminate/support version 9 and 10

